### PR TITLE
feat: add detailed buddy watch progress

### DIFF
--- a/Jellyfin.Plugin.BingeBuddy/Abstractions/IBingeBuddyOverlayService.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Abstractions/IBingeBuddyOverlayService.cs
@@ -15,5 +15,5 @@ public interface IBingeBuddyOverlayService
     /// <param name="userId">The authenticated user identifier.</param>
     /// <param name="itemIds">The media item identifiers.</param>
     /// <returns>Watchers keyed by item identifier.</returns>
-    IReadOnlyDictionary<Guid, IReadOnlyList<GroupWatcherDto>> GetOverlaysForUser(Guid userId, IReadOnlyList<Guid> itemIds);
+    IReadOnlyDictionary<Guid, ItemOverlayDto> GetOverlaysForUser(Guid userId, IReadOnlyList<Guid> itemIds);
 }

--- a/Jellyfin.Plugin.BingeBuddy/Abstractions/IBingeBuddyOverlayService.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Abstractions/IBingeBuddyOverlayService.cs
@@ -15,5 +15,5 @@ public interface IBingeBuddyOverlayService
     /// <param name="userId">The authenticated user identifier.</param>
     /// <param name="itemIds">The media item identifiers.</param>
     /// <returns>Watchers keyed by item identifier.</returns>
-    IReadOnlyDictionary<Guid, IReadOnlyList<GroupUserDto>> GetOverlaysForUser(Guid userId, IReadOnlyList<Guid> itemIds);
+    IReadOnlyDictionary<Guid, IReadOnlyList<GroupWatcherDto>> GetOverlaysForUser(Guid userId, IReadOnlyList<Guid> itemIds);
 }

--- a/Jellyfin.Plugin.BingeBuddy/Abstractions/IItemWatchProgressService.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Abstractions/IItemWatchProgressService.cs
@@ -15,7 +15,7 @@ public interface IItemWatchProgressService
     /// <param name="currentUserId">The authenticated user identifier.</param>
     /// <param name="itemIds">The media item identifiers.</param>
     /// <returns>Watchers keyed by item identifier.</returns>
-    IReadOnlyDictionary<Guid, IReadOnlyList<GroupUserDto>> GetWatchersForItems(
+    IReadOnlyDictionary<Guid, IReadOnlyList<GroupWatcherDto>> GetWatchersForItems(
         Guid currentUserId,
         IReadOnlyList<Guid> itemIds);
 }

--- a/Jellyfin.Plugin.BingeBuddy/Abstractions/IItemWatchProgressService.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Abstractions/IItemWatchProgressService.cs
@@ -5,7 +5,7 @@ using Jellyfin.Plugin.BingeBuddy.Api;
 namespace Jellyfin.Plugin.BingeBuddy.Abstractions;
 
 /// <summary>
-/// Determines which group members have started watching media items.
+/// Determines which group members have started watching media items, episodes, or season episodes.
 /// </summary>
 public interface IItemWatchProgressService
 {

--- a/Jellyfin.Plugin.BingeBuddy/Abstractions/IItemWatchProgressService.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Abstractions/IItemWatchProgressService.cs
@@ -14,8 +14,8 @@ public interface IItemWatchProgressService
     /// </summary>
     /// <param name="currentUserId">The authenticated user identifier.</param>
     /// <param name="itemIds">The media item identifiers.</param>
-    /// <returns>Watchers keyed by item identifier.</returns>
-    IReadOnlyDictionary<Guid, IReadOnlyList<GroupWatcherDto>> GetWatchersForItems(
+    /// <returns>Overlay data keyed by item identifier.</returns>
+    IReadOnlyDictionary<Guid, ItemOverlayDto> GetItemOverlays(
         Guid currentUserId,
         IReadOnlyList<Guid> itemIds);
 }

--- a/Jellyfin.Plugin.BingeBuddy/Abstractions/IUserProfileService.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Abstractions/IUserProfileService.cs
@@ -22,4 +22,14 @@ public interface IUserProfileService
     /// <param name="avatarSize">The avatar size in pixels.</param>
     /// <returns>The mapped DTO, if the user exists.</returns>
     GroupUserDto? MapUser(Guid userId, int avatarSize = 88);
+
+    /// <summary>
+    /// Maps a Jellyfin user and watch progress to a watcher DTO.
+    /// </summary>
+    /// <param name="userId">The Jellyfin user identifier.</param>
+    /// <param name="played">Whether the user marked the item as played.</param>
+    /// <param name="playbackPositionTicks">The saved playback position in Jellyfin ticks.</param>
+    /// <param name="avatarSize">The avatar size in pixels.</param>
+    /// <returns>The mapped DTO, if the user exists.</returns>
+    GroupWatcherDto? MapWatcher(Guid userId, bool played, long playbackPositionTicks, int avatarSize = 88);
 }

--- a/Jellyfin.Plugin.BingeBuddy/Abstractions/IUserProfileService.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Abstractions/IUserProfileService.cs
@@ -30,6 +30,14 @@ public interface IUserProfileService
     /// <param name="played">Whether the user marked the item as played.</param>
     /// <param name="playbackPositionTicks">The saved playback position in Jellyfin ticks.</param>
     /// <param name="avatarSize">The avatar size in pixels.</param>
+    /// <param name="episodeIndexNumber">The highest started episode index within a season, when applicable.</param>
+    /// <param name="episodeRunTimeTicks">The runtime of the referenced episode in Jellyfin ticks.</param>
     /// <returns>The mapped DTO, if the user exists.</returns>
-    GroupWatcherDto? MapWatcher(Guid userId, bool played, long playbackPositionTicks, int avatarSize = 88);
+    GroupWatcherDto? MapWatcher(
+        Guid userId,
+        bool played,
+        long playbackPositionTicks,
+        int avatarSize = 88,
+        int? episodeIndexNumber = null,
+        long episodeRunTimeTicks = 0);
 }

--- a/Jellyfin.Plugin.BingeBuddy/Api/BingeBuddyClientController.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Api/BingeBuddyClientController.cs
@@ -78,7 +78,7 @@ public class BingeBuddyClientController : ControllerBase
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public ActionResult<IReadOnlyDictionary<string, IReadOnlyList<GroupUserDto>>> GetOverlays([FromQuery] Guid[] itemIds)
+    public ActionResult<IReadOnlyDictionary<string, IReadOnlyList<GroupWatcherDto>>> GetOverlays([FromQuery] Guid[] itemIds)
     {
         var userId = GetAuthenticatedUserId();
         if (userId == Guid.Empty)

--- a/Jellyfin.Plugin.BingeBuddy/Api/BingeBuddyClientController.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Api/BingeBuddyClientController.cs
@@ -78,7 +78,7 @@ public class BingeBuddyClientController : ControllerBase
     [Produces("application/json")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public ActionResult<IReadOnlyDictionary<string, IReadOnlyList<GroupWatcherDto>>> GetOverlays([FromQuery] Guid[] itemIds)
+    public ActionResult<IReadOnlyDictionary<string, ItemOverlayDto>> GetOverlays([FromQuery] Guid[] itemIds)
     {
         var userId = GetAuthenticatedUserId();
         if (userId == Guid.Empty)

--- a/Jellyfin.Plugin.BingeBuddy/Api/GroupWatcherDto.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Api/GroupWatcherDto.cs
@@ -1,0 +1,17 @@
+namespace Jellyfin.Plugin.BingeBuddy.Api;
+
+/// <summary>
+/// Group member watch state for a media item.
+/// </summary>
+public class GroupWatcherDto : GroupUserDto
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the user marked the item as played.
+    /// </summary>
+    public bool Played { get; set; }
+
+    /// <summary>
+    /// Gets or sets the saved playback position in Jellyfin ticks.
+    /// </summary>
+    public long PlaybackPositionTicks { get; set; }
+}

--- a/Jellyfin.Plugin.BingeBuddy/Api/GroupWatcherDto.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Api/GroupWatcherDto.cs
@@ -14,4 +14,14 @@ public class GroupWatcherDto : GroupUserDto
     /// Gets or sets the saved playback position in Jellyfin ticks.
     /// </summary>
     public long PlaybackPositionTicks { get; set; }
+
+    /// <summary>
+    /// Gets or sets the highest started episode index within a season, when applicable.
+    /// </summary>
+    public int? EpisodeIndexNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the runtime of <see cref="EpisodeIndexNumber"/> in Jellyfin ticks.
+    /// </summary>
+    public long EpisodeRunTimeTicks { get; set; }
 }

--- a/Jellyfin.Plugin.BingeBuddy/Api/ItemOverlayDto.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Api/ItemOverlayDto.cs
@@ -14,6 +14,11 @@ public class ItemOverlayDto
     public long RunTimeTicks { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the overlay item is a TV season.
+    /// </summary>
+    public bool IsSeason { get; set; }
+
+    /// <summary>
     /// Gets or sets the authenticated user's watch progress.
     /// </summary>
     public WatchProgressDto CurrentUser { get; set; } = new();

--- a/Jellyfin.Plugin.BingeBuddy/Api/ItemOverlayDto.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Api/ItemOverlayDto.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.BingeBuddy.Api;
+
+/// <summary>
+/// Overlay data for a media item, including buddy watch progress.
+/// </summary>
+public class ItemOverlayDto
+{
+    /// <summary>
+    /// Gets or sets the item runtime in Jellyfin ticks.
+    /// </summary>
+    public long RunTimeTicks { get; set; }
+
+    /// <summary>
+    /// Gets or sets the authenticated user's watch progress.
+    /// </summary>
+    public WatchProgressDto CurrentUser { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets group members who have started the item.
+    /// </summary>
+    public IReadOnlyList<GroupWatcherDto> Watchers { get; set; } = Array.Empty<GroupWatcherDto>();
+}

--- a/Jellyfin.Plugin.BingeBuddy/Api/WatchProgressDto.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Api/WatchProgressDto.cs
@@ -1,0 +1,17 @@
+namespace Jellyfin.Plugin.BingeBuddy.Api;
+
+/// <summary>
+/// Jellyfin watch state for a media item.
+/// </summary>
+public class WatchProgressDto
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether Jellyfin marks the item as played.
+    /// </summary>
+    public bool Played { get; set; }
+
+    /// <summary>
+    /// Gets or sets the saved playback position in Jellyfin ticks.
+    /// </summary>
+    public long PlaybackPositionTicks { get; set; }
+}

--- a/Jellyfin.Plugin.BingeBuddy/Api/WatchProgressDto.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Api/WatchProgressDto.cs
@@ -14,4 +14,14 @@ public class WatchProgressDto
     /// Gets or sets the saved playback position in Jellyfin ticks.
     /// </summary>
     public long PlaybackPositionTicks { get; set; }
+
+    /// <summary>
+    /// Gets or sets the highest started episode index within a season, when applicable.
+    /// </summary>
+    public int? EpisodeIndexNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the runtime of <see cref="EpisodeIndexNumber"/> in Jellyfin ticks.
+    /// </summary>
+    public long EpisodeRunTimeTicks { get; set; }
 }

--- a/Jellyfin.Plugin.BingeBuddy/Services/BingeBuddyOverlayService.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Services/BingeBuddyOverlayService.cs
@@ -25,11 +25,11 @@ public class BingeBuddyOverlayService : IBingeBuddyOverlayService
     }
 
     /// <inheritdoc />
-    public IReadOnlyDictionary<Guid, IReadOnlyList<GroupUserDto>> GetOverlaysForUser(Guid userId, IReadOnlyList<Guid> itemIds)
+    public IReadOnlyDictionary<Guid, IReadOnlyList<GroupWatcherDto>> GetOverlaysForUser(Guid userId, IReadOnlyList<Guid> itemIds)
     {
         if (itemIds.Count == 0 || userId == Guid.Empty)
         {
-            return new Dictionary<Guid, IReadOnlyList<GroupUserDto>>();
+            return new Dictionary<Guid, IReadOnlyList<GroupWatcherDto>>();
         }
 
         var limitedItemIds = itemIds.Count <= MaxItemsPerRequest

--- a/Jellyfin.Plugin.BingeBuddy/Services/BingeBuddyOverlayService.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Services/BingeBuddyOverlayService.cs
@@ -25,17 +25,17 @@ public class BingeBuddyOverlayService : IBingeBuddyOverlayService
     }
 
     /// <inheritdoc />
-    public IReadOnlyDictionary<Guid, IReadOnlyList<GroupWatcherDto>> GetOverlaysForUser(Guid userId, IReadOnlyList<Guid> itemIds)
+    public IReadOnlyDictionary<Guid, ItemOverlayDto> GetOverlaysForUser(Guid userId, IReadOnlyList<Guid> itemIds)
     {
         if (itemIds.Count == 0 || userId == Guid.Empty)
         {
-            return new Dictionary<Guid, IReadOnlyList<GroupWatcherDto>>();
+            return new Dictionary<Guid, ItemOverlayDto>();
         }
 
         var limitedItemIds = itemIds.Count <= MaxItemsPerRequest
             ? itemIds
             : itemIds.Take(MaxItemsPerRequest).ToList();
 
-        return _itemWatchProgressService.GetWatchersForItems(userId, limitedItemIds);
+        return _itemWatchProgressService.GetItemOverlays(userId, limitedItemIds);
     }
 }

--- a/Jellyfin.Plugin.BingeBuddy/Services/ItemWatchProgressService.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Services/ItemWatchProgressService.cs
@@ -45,11 +45,11 @@ public class ItemWatchProgressService : IItemWatchProgressService
     }
 
     /// <inheritdoc />
-    public IReadOnlyDictionary<Guid, IReadOnlyList<GroupUserDto>> GetWatchersForItems(
+    public IReadOnlyDictionary<Guid, IReadOnlyList<GroupWatcherDto>> GetWatchersForItems(
         Guid currentUserId,
         IReadOnlyList<Guid> itemIds)
     {
-        var result = new Dictionary<Guid, IReadOnlyList<GroupUserDto>>();
+        var result = new Dictionary<Guid, IReadOnlyList<GroupWatcherDto>>();
         if (itemIds.Count == 0)
         {
             return result;
@@ -60,7 +60,7 @@ public class ItemWatchProgressService : IItemWatchProgressService
         {
             foreach (var itemId in itemIds.Distinct())
             {
-                result[itemId] = Array.Empty<GroupUserDto>();
+                result[itemId] = Array.Empty<GroupWatcherDto>();
             }
 
             return result;
@@ -73,7 +73,7 @@ public class ItemWatchProgressService : IItemWatchProgressService
 
         foreach (var unsupportedItemId in distinctItemIds.Except(supportedItemIds))
         {
-            result[unsupportedItemId] = Array.Empty<GroupUserDto>();
+            result[unsupportedItemId] = Array.Empty<GroupWatcherDto>();
         }
 
         if (supportedItemIds.Count == 0)
@@ -81,13 +81,17 @@ public class ItemWatchProgressService : IItemWatchProgressService
             return result;
         }
 
-        var startedMembersByItem = LoadStartedMembersByItem(supportedItemIds, visibleMemberIds);
+        var watcherProgressByItem = LoadWatcherProgressByItem(supportedItemIds, visibleMemberIds);
 
         foreach (var itemId in supportedItemIds)
         {
-            var startedMemberIds = startedMembersByItem.GetValueOrDefault(itemId) ?? Array.Empty<Guid>();
-            var watchers = startedMemberIds
-                .Select(memberId => _userProfileService.MapUser(memberId, OverlayAvatarSize))
+            var watcherProgress = watcherProgressByItem.GetValueOrDefault(itemId) ?? Array.Empty<MemberWatchProgress>();
+            var watchers = watcherProgress
+                .Select(progress => _userProfileService.MapWatcher(
+                    progress.UserId,
+                    progress.Played,
+                    progress.PlaybackPositionTicks,
+                    OverlayAvatarSize))
                 .Where(watcher => watcher is not null)
                 .Select(watcher => watcher!)
                 .OrderBy(watcher => watcher.Name, StringComparer.OrdinalIgnoreCase)
@@ -99,7 +103,7 @@ public class ItemWatchProgressService : IItemWatchProgressService
         return result;
     }
 
-    private Dictionary<Guid, IReadOnlyList<Guid>> LoadStartedMembersByItem(
+    private Dictionary<Guid, IReadOnlyList<MemberWatchProgress>> LoadWatcherProgressByItem(
         IReadOnlyList<Guid> itemIds,
         IReadOnlyList<Guid> memberIds)
     {
@@ -110,7 +114,7 @@ public class ItemWatchProgressService : IItemWatchProgressService
             .Where(userData => itemIds.Contains(userData.ItemId) && memberIds.Contains(userData.UserId))
             .ToList();
 
-        var startedMembersByItem = itemIds.ToDictionary(itemId => itemId, _ => new HashSet<Guid>());
+        var progressByItem = itemIds.ToDictionary(itemId => itemId, _ => new Dictionary<Guid, MemberWatchProgress>());
 
         foreach (var row in rows)
         {
@@ -119,15 +123,22 @@ public class ItemWatchProgressService : IItemWatchProgressService
                 continue;
             }
 
-            if (startedMembersByItem.TryGetValue(row.ItemId, out var memberSet))
+            if (!progressByItem.TryGetValue(row.ItemId, out var progressByUser))
             {
-                memberSet.Add(row.UserId);
+                continue;
             }
+
+            progressByUser[row.UserId] = new MemberWatchProgress(
+                row.UserId,
+                row.Played,
+                row.PlaybackPositionTicks);
         }
 
-        return startedMembersByItem.ToDictionary(
+        return progressByItem.ToDictionary(
             entry => entry.Key,
-            entry => (IReadOnlyList<Guid>)entry.Value.OrderBy(id => id).ToList());
+            entry => (IReadOnlyList<MemberWatchProgress>)entry.Value.Values
+                .OrderBy(progress => progress.UserId)
+                .ToList());
     }
 
     private bool TryGetSupportedItem(Guid itemId, Guid currentUserId, out BaseItem item)
@@ -165,4 +176,6 @@ public class ItemWatchProgressService : IItemWatchProgressService
             || userData.PlaybackPositionTicks > 0
             || userData.LastPlayedDate.HasValue;
     }
+
+    private sealed record MemberWatchProgress(Guid UserId, bool Played, long PlaybackPositionTicks);
 }

--- a/Jellyfin.Plugin.BingeBuddy/Services/ItemWatchProgressService.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Services/ItemWatchProgressService.cs
@@ -45,100 +45,125 @@ public class ItemWatchProgressService : IItemWatchProgressService
     }
 
     /// <inheritdoc />
-    public IReadOnlyDictionary<Guid, IReadOnlyList<GroupWatcherDto>> GetWatchersForItems(
+    public IReadOnlyDictionary<Guid, ItemOverlayDto> GetItemOverlays(
         Guid currentUserId,
         IReadOnlyList<Guid> itemIds)
     {
-        var result = new Dictionary<Guid, IReadOnlyList<GroupWatcherDto>>();
+        var result = new Dictionary<Guid, ItemOverlayDto>();
         if (itemIds.Count == 0)
         {
             return result;
         }
 
+        var distinctItemIds = itemIds.Distinct().ToList();
         var visibleMemberIds = _groupMembershipService.GetVisibleMemberIds(currentUserId);
-        if (visibleMemberIds.Count == 0)
+        var runTimeTicksByItem = new Dictionary<Guid, long>();
+
+        foreach (var itemId in distinctItemIds)
         {
-            foreach (var itemId in itemIds.Distinct())
+            if (!TryGetSupportedItem(itemId, currentUserId, out var item))
             {
-                result[itemId] = Array.Empty<GroupWatcherDto>();
+                result[itemId] = CreateEmptyOverlay();
+                continue;
             }
 
-            return result;
+            runTimeTicksByItem[itemId] = item.RunTimeTicks ?? 0;
         }
 
-        var distinctItemIds = itemIds.Distinct().ToList();
-        var supportedItemIds = distinctItemIds
-            .Where(itemId => TryGetSupportedItem(itemId, currentUserId, out _))
-            .ToList();
-
-        foreach (var unsupportedItemId in distinctItemIds.Except(supportedItemIds))
-        {
-            result[unsupportedItemId] = Array.Empty<GroupWatcherDto>();
-        }
-
-        if (supportedItemIds.Count == 0)
+        if (runTimeTicksByItem.Count == 0)
         {
             return result;
         }
 
-        var watcherProgressByItem = LoadWatcherProgressByItem(supportedItemIds, visibleMemberIds);
+        var overlayProgress = LoadOverlayProgress(
+            runTimeTicksByItem.Keys.ToList(),
+            visibleMemberIds,
+            currentUserId);
 
-        foreach (var itemId in supportedItemIds)
+        foreach (var itemId in runTimeTicksByItem.Keys)
         {
-            var watcherProgress = watcherProgressByItem.GetValueOrDefault(itemId) ?? Array.Empty<MemberWatchProgress>();
+            var progress = overlayProgress.GetValueOrDefault(itemId);
+            var currentUserProgress = progress?.CurrentUser ?? new WatchProgressDto();
+            var watcherProgress = progress?.Watchers.Values.ToList() ?? new List<MemberWatchProgress>();
+
             var watchers = watcherProgress
-                .Select(progress => _userProfileService.MapWatcher(
-                    progress.UserId,
-                    progress.Played,
-                    progress.PlaybackPositionTicks,
+                .Select(memberProgress => _userProfileService.MapWatcher(
+                    memberProgress.UserId,
+                    memberProgress.Played,
+                    memberProgress.PlaybackPositionTicks,
                     OverlayAvatarSize))
                 .Where(watcher => watcher is not null)
                 .Select(watcher => watcher!)
                 .OrderBy(watcher => watcher.Name, StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
-            result[itemId] = watchers;
+            result[itemId] = new ItemOverlayDto
+            {
+                RunTimeTicks = runTimeTicksByItem[itemId],
+                CurrentUser = currentUserProgress,
+                Watchers = watchers
+            };
         }
 
         return result;
     }
 
-    private Dictionary<Guid, IReadOnlyList<MemberWatchProgress>> LoadWatcherProgressByItem(
+    private static ItemOverlayDto CreateEmptyOverlay()
+    {
+        return new ItemOverlayDto
+        {
+            RunTimeTicks = 0,
+            CurrentUser = new WatchProgressDto(),
+            Watchers = Array.Empty<GroupWatcherDto>()
+        };
+    }
+
+    private Dictionary<Guid, ItemProgressSnapshot> LoadOverlayProgress(
         IReadOnlyList<Guid> itemIds,
-        IReadOnlyList<Guid> memberIds)
+        IReadOnlyList<Guid> memberIds,
+        Guid currentUserId)
     {
         using var context = _dbContextFactory.CreateDbContext();
 
-        var rows = context.UserData
-            .AsNoTracking()
-            .Where(userData => itemIds.Contains(userData.ItemId) && memberIds.Contains(userData.UserId))
+        var trackedUserIds = memberIds
+            .Append(currentUserId)
+            .Distinct()
             .ToList();
 
-        var progressByItem = itemIds.ToDictionary(itemId => itemId, _ => new Dictionary<Guid, MemberWatchProgress>());
+        var rows = context.UserData
+            .AsNoTracking()
+            .Where(userData => itemIds.Contains(userData.ItemId) && trackedUserIds.Contains(userData.UserId))
+            .ToList();
+
+        var snapshots = itemIds.ToDictionary(
+            itemId => itemId,
+            _ => new ItemProgressSnapshot());
 
         foreach (var row in rows)
         {
+            if (!snapshots.TryGetValue(row.ItemId, out var snapshot))
+            {
+                continue;
+            }
+
+            if (row.UserId == currentUserId)
+            {
+                snapshot.CurrentUser = MapWatchProgress(row);
+                continue;
+            }
+
             if (!HasStartedWatching(row))
             {
                 continue;
             }
 
-            if (!progressByItem.TryGetValue(row.ItemId, out var progressByUser))
-            {
-                continue;
-            }
-
-            progressByUser[row.UserId] = new MemberWatchProgress(
+            snapshot.Watchers[row.UserId] = new MemberWatchProgress(
                 row.UserId,
                 row.Played,
                 row.PlaybackPositionTicks);
         }
 
-        return progressByItem.ToDictionary(
-            entry => entry.Key,
-            entry => (IReadOnlyList<MemberWatchProgress>)entry.Value.Values
-                .OrderBy(progress => progress.UserId)
-                .ToList());
+        return snapshots;
     }
 
     private bool TryGetSupportedItem(Guid itemId, Guid currentUserId, out BaseItem item)
@@ -169,6 +194,15 @@ public class ItemWatchProgressService : IItemWatchProgressService
         return false;
     }
 
+    private static WatchProgressDto MapWatchProgress(UserData userData)
+    {
+        return new WatchProgressDto
+        {
+            Played = userData.Played,
+            PlaybackPositionTicks = userData.PlaybackPositionTicks
+        };
+    }
+
     private static bool HasStartedWatching(UserData userData)
     {
         return userData.Played
@@ -178,4 +212,11 @@ public class ItemWatchProgressService : IItemWatchProgressService
     }
 
     private sealed record MemberWatchProgress(Guid UserId, bool Played, long PlaybackPositionTicks);
+
+    private sealed class ItemProgressSnapshot
+    {
+        public WatchProgressDto CurrentUser { get; set; } = new();
+
+        public Dictionary<Guid, MemberWatchProgress> Watchers { get; } = new();
+    }
 }

--- a/Jellyfin.Plugin.BingeBuddy/Services/ItemWatchProgressService.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Services/ItemWatchProgressService.cs
@@ -66,7 +66,7 @@ public class ItemWatchProgressService : IItemWatchProgressService
 
         foreach (var itemId in distinctItemIds)
         {
-            if (!TryResolveOverlayItem(itemId, currentUserId, out var item, out var context))
+            if (!TryResolveOverlayItem(itemId, currentUserId, out _, out var context))
             {
                 result[itemId] = CreateEmptyOverlay();
                 continue;
@@ -93,7 +93,9 @@ public class ItemWatchProgressService : IItemWatchProgressService
                     memberProgress.UserId,
                     memberProgress.Played,
                     memberProgress.PlaybackPositionTicks,
-                    OverlayAvatarSize))
+                    OverlayAvatarSize,
+                    memberProgress.EpisodeIndexNumber,
+                    memberProgress.EpisodeRunTimeTicks))
                 .Where(watcher => watcher is not null)
                 .Select(watcher => watcher!)
                 .OrderBy(watcher => watcher.Name, StringComparer.OrdinalIgnoreCase)
@@ -101,6 +103,7 @@ public class ItemWatchProgressService : IItemWatchProgressService
 
             result[itemId] = new ItemOverlayDto
             {
+                IsSeason = context.IsSeason,
                 RunTimeTicks = context.RunTimeTicks,
                 CurrentUser = currentUserProgress,
                 Watchers = watchers
@@ -176,6 +179,17 @@ public class ItemWatchProgressService : IItemWatchProgressService
                     continue;
                 }
 
+                if (!itemContexts.TryGetValue(overlayItemId, out var overlayContext))
+                {
+                    continue;
+                }
+
+                if (overlayContext.IsSeason)
+                {
+                    ApplySeasonRow(snapshot, row, overlayContext, currentUserId);
+                    continue;
+                }
+
                 if (row.UserId == currentUserId)
                 {
                     snapshot.CurrentUser = MergeWatchProgress(snapshot.CurrentUser, MapWatchProgress(row));
@@ -190,20 +204,58 @@ public class ItemWatchProgressService : IItemWatchProgressService
                 var incoming = new MemberWatchProgress(
                     row.UserId,
                     row.Played,
-                    row.PlaybackPositionTicks);
+                    row.PlaybackPositionTicks,
+                    null,
+                    0);
 
-                if (snapshot.Watchers.TryGetValue(row.UserId, out var existing))
-                {
-                    snapshot.Watchers[row.UserId] = MergeMemberProgress(existing, incoming);
-                }
-                else
-                {
-                    snapshot.Watchers[row.UserId] = incoming;
-                }
+                snapshot.Watchers[row.UserId] = snapshot.Watchers.TryGetValue(row.UserId, out var existing)
+                    ? MergeMemberProgress(existing, incoming)
+                    : incoming;
             }
         }
 
         return snapshots;
+    }
+
+    private static void ApplySeasonRow(
+        ItemProgressSnapshot snapshot,
+        UserData row,
+        OverlayItemContext overlayContext,
+        Guid currentUserId)
+    {
+        if (!overlayContext.EpisodeMetadataById.TryGetValue(row.ItemId, out var episodeMetadata))
+        {
+            return;
+        }
+
+        if (row.UserId == currentUserId)
+        {
+            if (!HasStartedWatching(row))
+            {
+                return;
+            }
+
+            snapshot.CurrentUser = MergeSeasonWatchProgress(
+                snapshot.CurrentUser,
+                MapSeasonWatchProgress(row, episodeMetadata));
+            return;
+        }
+
+        if (!HasStartedWatching(row))
+        {
+            return;
+        }
+
+        var incoming = new MemberWatchProgress(
+            row.UserId,
+            row.Played,
+            row.PlaybackPositionTicks,
+            episodeMetadata.IndexNumber,
+            episodeMetadata.RunTimeTicks);
+
+        snapshot.Watchers[row.UserId] = snapshot.Watchers.TryGetValue(row.UserId, out var existing)
+            ? MergeSeasonMemberProgress(existing, incoming)
+            : incoming;
     }
 
     private bool TryResolveOverlayItem(
@@ -255,10 +307,13 @@ public class ItemWatchProgressService : IItemWatchProgressService
         if (resolvedItem is Season season)
         {
             item = season;
+            var episodes = GetSeasonEpisodes(season, currentUserId);
             context = new OverlayItemContext
             {
+                IsSeason = true,
                 RunTimeTicks = 0,
-                ProgressItemIds = GetEpisodeIds(season, currentUserId)
+                ProgressItemIds = episodes.Select(episode => episode.Id).ToList(),
+                EpisodeMetadataById = BuildEpisodeMetadata(episodes)
             };
             return true;
         }
@@ -266,12 +321,40 @@ public class ItemWatchProgressService : IItemWatchProgressService
         return false;
     }
 
-    private List<Guid> GetEpisodeIds(Season season, Guid userId)
+    private List<BaseItem> GetSeasonEpisodes(Season season, Guid userId)
     {
         var user = _userManager.GetUserById(userId);
-        return season.GetEpisodes(user, new DtoOptions(true), shouldIncludeMissingEpisodes: true)
-            .Select(episode => episode.Id)
+        return season.GetEpisodes(user, new DtoOptions(true), shouldIncludeMissingEpisodes: true);
+    }
+
+    private static Dictionary<Guid, EpisodeMetadata> BuildEpisodeMetadata(IReadOnlyList<BaseItem> episodes)
+    {
+        var orderedEpisodes = episodes
+            .OrderBy(episode => episode.IndexNumber ?? int.MaxValue)
+            .ThenBy(episode => episode.SortName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(episode => episode.Id)
             .ToList();
+
+        var metadata = new Dictionary<Guid, EpisodeMetadata>();
+        for (var i = 0; i < orderedEpisodes.Count; i++)
+        {
+            var episode = orderedEpisodes[i];
+            metadata[episode.Id] = new EpisodeMetadata(
+                ResolveEpisodeNumber(episode, i + 1),
+                episode.RunTimeTicks ?? 0);
+        }
+
+        return metadata;
+    }
+
+    private static int ResolveEpisodeNumber(BaseItem episode, int fallbackNumber)
+    {
+        if (episode.IndexNumber is > 0)
+        {
+            return episode.IndexNumber.Value;
+        }
+
+        return fallbackNumber;
     }
 
     private static WatchProgressDto MapWatchProgress(UserData userData)
@@ -283,8 +366,49 @@ public class ItemWatchProgressService : IItemWatchProgressService
         };
     }
 
+    private static WatchProgressDto MapSeasonWatchProgress(UserData userData, EpisodeMetadata episodeMetadata)
+    {
+        return new WatchProgressDto
+        {
+            Played = userData.Played,
+            PlaybackPositionTicks = userData.PlaybackPositionTicks,
+            EpisodeIndexNumber = episodeMetadata.IndexNumber,
+            EpisodeRunTimeTicks = episodeMetadata.RunTimeTicks
+        };
+    }
+
     private static WatchProgressDto MergeWatchProgress(WatchProgressDto existing, WatchProgressDto incoming)
     {
+        if (incoming.Played)
+        {
+            return incoming;
+        }
+
+        if (existing.Played)
+        {
+            return existing;
+        }
+
+        return incoming.PlaybackPositionTicks > existing.PlaybackPositionTicks
+            ? incoming
+            : existing;
+    }
+
+    private static WatchProgressDto MergeSeasonWatchProgress(WatchProgressDto existing, WatchProgressDto incoming)
+    {
+        var existingIndex = existing.EpisodeIndexNumber ?? -1;
+        var incomingIndex = incoming.EpisodeIndexNumber ?? -1;
+
+        if (incomingIndex > existingIndex)
+        {
+            return incoming;
+        }
+
+        if (incomingIndex < existingIndex)
+        {
+            return existing;
+        }
+
         if (incoming.Played)
         {
             return incoming;
@@ -317,6 +441,36 @@ public class ItemWatchProgressService : IItemWatchProgressService
             : existing;
     }
 
+    private static MemberWatchProgress MergeSeasonMemberProgress(MemberWatchProgress existing, MemberWatchProgress incoming)
+    {
+        var existingIndex = existing.EpisodeIndexNumber ?? -1;
+        var incomingIndex = incoming.EpisodeIndexNumber ?? -1;
+
+        if (incomingIndex > existingIndex)
+        {
+            return incoming;
+        }
+
+        if (incomingIndex < existingIndex)
+        {
+            return existing;
+        }
+
+        if (incoming.Played)
+        {
+            return incoming;
+        }
+
+        if (existing.Played)
+        {
+            return existing;
+        }
+
+        return incoming.PlaybackPositionTicks > existing.PlaybackPositionTicks
+            ? incoming
+            : existing;
+    }
+
     private static bool HasStartedWatching(UserData userData)
     {
         return userData.Played
@@ -325,13 +479,24 @@ public class ItemWatchProgressService : IItemWatchProgressService
             || userData.LastPlayedDate.HasValue;
     }
 
-    private sealed record MemberWatchProgress(Guid UserId, bool Played, long PlaybackPositionTicks);
+    private sealed record EpisodeMetadata(int IndexNumber, long RunTimeTicks);
+
+    private sealed record MemberWatchProgress(
+        Guid UserId,
+        bool Played,
+        long PlaybackPositionTicks,
+        int? EpisodeIndexNumber,
+        long EpisodeRunTimeTicks);
 
     private sealed class OverlayItemContext
     {
+        public bool IsSeason { get; init; }
+
         public long RunTimeTicks { get; init; }
 
         public IReadOnlyList<Guid> ProgressItemIds { get; init; } = Array.Empty<Guid>();
+
+        public Dictionary<Guid, EpisodeMetadata> EpisodeMetadataById { get; init; } = new();
     }
 
     private sealed class ItemProgressSnapshot

--- a/Jellyfin.Plugin.BingeBuddy/Services/ItemWatchProgressService.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Services/ItemWatchProgressService.cs
@@ -5,6 +5,7 @@ using Jellyfin.Database.Implementations;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.BingeBuddy.Abstractions;
 using Jellyfin.Plugin.BingeBuddy.Api;
+using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
@@ -23,6 +24,7 @@ public class ItemWatchProgressService : IItemWatchProgressService
     private readonly IGroupMembershipService _groupMembershipService;
     private readonly IUserProfileService _userProfileService;
     private readonly ILibraryManager _libraryManager;
+    private readonly IUserManager _userManager;
     private readonly IDbContextFactory<JellyfinDbContext> _dbContextFactory;
 
     /// <summary>
@@ -31,16 +33,19 @@ public class ItemWatchProgressService : IItemWatchProgressService
     /// <param name="groupMembershipService">The group membership service.</param>
     /// <param name="userProfileService">The user profile service.</param>
     /// <param name="libraryManager">The Jellyfin library manager.</param>
+    /// <param name="userManager">The Jellyfin user manager.</param>
     /// <param name="dbContextFactory">The Jellyfin database context factory.</param>
     public ItemWatchProgressService(
         IGroupMembershipService groupMembershipService,
         IUserProfileService userProfileService,
         ILibraryManager libraryManager,
+        IUserManager userManager,
         IDbContextFactory<JellyfinDbContext> dbContextFactory)
     {
         _groupMembershipService = groupMembershipService;
         _userProfileService = userProfileService;
         _libraryManager = libraryManager;
+        _userManager = userManager;
         _dbContextFactory = dbContextFactory;
     }
 
@@ -57,30 +62,27 @@ public class ItemWatchProgressService : IItemWatchProgressService
 
         var distinctItemIds = itemIds.Distinct().ToList();
         var visibleMemberIds = _groupMembershipService.GetVisibleMemberIds(currentUserId);
-        var runTimeTicksByItem = new Dictionary<Guid, long>();
+        var itemContexts = new Dictionary<Guid, OverlayItemContext>();
 
         foreach (var itemId in distinctItemIds)
         {
-            if (!TryGetSupportedItem(itemId, currentUserId, out var item))
+            if (!TryResolveOverlayItem(itemId, currentUserId, out var item, out var context))
             {
                 result[itemId] = CreateEmptyOverlay();
                 continue;
             }
 
-            runTimeTicksByItem[itemId] = item.RunTimeTicks ?? 0;
+            itemContexts[itemId] = context;
         }
 
-        if (runTimeTicksByItem.Count == 0)
+        if (itemContexts.Count == 0)
         {
             return result;
         }
 
-        var overlayProgress = LoadOverlayProgress(
-            runTimeTicksByItem.Keys.ToList(),
-            visibleMemberIds,
-            currentUserId);
+        var overlayProgress = LoadOverlayProgress(itemContexts, visibleMemberIds, currentUserId);
 
-        foreach (var itemId in runTimeTicksByItem.Keys)
+        foreach (var (itemId, context) in itemContexts)
         {
             var progress = overlayProgress.GetValueOrDefault(itemId);
             var currentUserProgress = progress?.CurrentUser ?? new WatchProgressDto();
@@ -99,7 +101,7 @@ public class ItemWatchProgressService : IItemWatchProgressService
 
             result[itemId] = new ItemOverlayDto
             {
-                RunTimeTicks = runTimeTicksByItem[itemId],
+                RunTimeTicks = context.RunTimeTicks,
                 CurrentUser = currentUserProgress,
                 Watchers = watchers
             };
@@ -119,7 +121,7 @@ public class ItemWatchProgressService : IItemWatchProgressService
     }
 
     private Dictionary<Guid, ItemProgressSnapshot> LoadOverlayProgress(
-        IReadOnlyList<Guid> itemIds,
+        IReadOnlyDictionary<Guid, OverlayItemContext> itemContexts,
         IReadOnlyList<Guid> memberIds,
         Guid currentUserId)
     {
@@ -130,45 +132,88 @@ public class ItemWatchProgressService : IItemWatchProgressService
             .Distinct()
             .ToList();
 
+        var progressItemToOverlayIds = new Dictionary<Guid, List<Guid>>();
+        foreach (var (overlayItemId, overlayContext) in itemContexts)
+        {
+            foreach (var progressItemId in overlayContext.ProgressItemIds)
+            {
+                if (!progressItemToOverlayIds.TryGetValue(progressItemId, out var overlayItemIds))
+                {
+                    overlayItemIds = new List<Guid>();
+                    progressItemToOverlayIds[progressItemId] = overlayItemIds;
+                }
+
+                overlayItemIds.Add(overlayItemId);
+            }
+        }
+
+        var progressItemIds = progressItemToOverlayIds.Keys.ToList();
+        if (progressItemIds.Count == 0)
+        {
+            return itemContexts.Keys.ToDictionary(itemId => itemId, _ => new ItemProgressSnapshot());
+        }
+
         var rows = context.UserData
             .AsNoTracking()
-            .Where(userData => itemIds.Contains(userData.ItemId) && trackedUserIds.Contains(userData.UserId))
+            .Where(userData => progressItemIds.Contains(userData.ItemId) && trackedUserIds.Contains(userData.UserId))
             .ToList();
 
-        var snapshots = itemIds.ToDictionary(
+        var snapshots = itemContexts.Keys.ToDictionary(
             itemId => itemId,
             _ => new ItemProgressSnapshot());
 
         foreach (var row in rows)
         {
-            if (!snapshots.TryGetValue(row.ItemId, out var snapshot))
+            if (!progressItemToOverlayIds.TryGetValue(row.ItemId, out var overlayItemIds))
             {
                 continue;
             }
 
-            if (row.UserId == currentUserId)
+            foreach (var overlayItemId in overlayItemIds)
             {
-                snapshot.CurrentUser = MapWatchProgress(row);
-                continue;
-            }
+                if (!snapshots.TryGetValue(overlayItemId, out var snapshot))
+                {
+                    continue;
+                }
 
-            if (!HasStartedWatching(row))
-            {
-                continue;
-            }
+                if (row.UserId == currentUserId)
+                {
+                    snapshot.CurrentUser = MergeWatchProgress(snapshot.CurrentUser, MapWatchProgress(row));
+                    continue;
+                }
 
-            snapshot.Watchers[row.UserId] = new MemberWatchProgress(
-                row.UserId,
-                row.Played,
-                row.PlaybackPositionTicks);
+                if (!HasStartedWatching(row))
+                {
+                    continue;
+                }
+
+                var incoming = new MemberWatchProgress(
+                    row.UserId,
+                    row.Played,
+                    row.PlaybackPositionTicks);
+
+                if (snapshot.Watchers.TryGetValue(row.UserId, out var existing))
+                {
+                    snapshot.Watchers[row.UserId] = MergeMemberProgress(existing, incoming);
+                }
+                else
+                {
+                    snapshot.Watchers[row.UserId] = incoming;
+                }
+            }
         }
 
         return snapshots;
     }
 
-    private bool TryGetSupportedItem(Guid itemId, Guid currentUserId, out BaseItem item)
+    private bool TryResolveOverlayItem(
+        Guid itemId,
+        Guid currentUserId,
+        out BaseItem item,
+        out OverlayItemContext context)
     {
         item = null!;
+        context = null!;
 
         BaseItem? resolvedItem;
         try
@@ -185,13 +230,48 @@ public class ItemWatchProgressService : IItemWatchProgressService
             return false;
         }
 
-        if (resolvedItem is Movie or Episode)
+        if (resolvedItem is Movie movie)
         {
-            item = resolvedItem;
+            item = movie;
+            context = new OverlayItemContext
+            {
+                RunTimeTicks = movie.RunTimeTicks ?? 0,
+                ProgressItemIds = new[] { itemId }
+            };
+            return true;
+        }
+
+        if (resolvedItem is Episode episode)
+        {
+            item = episode;
+            context = new OverlayItemContext
+            {
+                RunTimeTicks = episode.RunTimeTicks ?? 0,
+                ProgressItemIds = new[] { itemId }
+            };
+            return true;
+        }
+
+        if (resolvedItem is Season season)
+        {
+            item = season;
+            context = new OverlayItemContext
+            {
+                RunTimeTicks = 0,
+                ProgressItemIds = GetEpisodeIds(season, currentUserId)
+            };
             return true;
         }
 
         return false;
+    }
+
+    private List<Guid> GetEpisodeIds(Season season, Guid userId)
+    {
+        var user = _userManager.GetUserById(userId);
+        return season.GetEpisodes(user, new DtoOptions(true), shouldIncludeMissingEpisodes: true)
+            .Select(episode => episode.Id)
+            .ToList();
     }
 
     private static WatchProgressDto MapWatchProgress(UserData userData)
@@ -203,6 +283,40 @@ public class ItemWatchProgressService : IItemWatchProgressService
         };
     }
 
+    private static WatchProgressDto MergeWatchProgress(WatchProgressDto existing, WatchProgressDto incoming)
+    {
+        if (incoming.Played)
+        {
+            return incoming;
+        }
+
+        if (existing.Played)
+        {
+            return existing;
+        }
+
+        return incoming.PlaybackPositionTicks > existing.PlaybackPositionTicks
+            ? incoming
+            : existing;
+    }
+
+    private static MemberWatchProgress MergeMemberProgress(MemberWatchProgress existing, MemberWatchProgress incoming)
+    {
+        if (incoming.Played)
+        {
+            return incoming;
+        }
+
+        if (existing.Played)
+        {
+            return existing;
+        }
+
+        return incoming.PlaybackPositionTicks > existing.PlaybackPositionTicks
+            ? incoming
+            : existing;
+    }
+
     private static bool HasStartedWatching(UserData userData)
     {
         return userData.Played
@@ -212,6 +326,13 @@ public class ItemWatchProgressService : IItemWatchProgressService
     }
 
     private sealed record MemberWatchProgress(Guid UserId, bool Played, long PlaybackPositionTicks);
+
+    private sealed class OverlayItemContext
+    {
+        public long RunTimeTicks { get; init; }
+
+        public IReadOnlyList<Guid> ProgressItemIds { get; init; } = Array.Empty<Guid>();
+    }
 
     private sealed class ItemProgressSnapshot
     {

--- a/Jellyfin.Plugin.BingeBuddy/Services/UserProfileService.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Services/UserProfileService.cs
@@ -64,4 +64,25 @@ public class UserProfileService : IUserProfileService
             ImageUrl = imageUrl
         };
     }
+
+    /// <inheritdoc />
+    public GroupWatcherDto? MapWatcher(Guid userId, bool played, long playbackPositionTicks, int avatarSize = 88)
+    {
+        var user = MapUser(userId, avatarSize);
+        if (user is null)
+        {
+            return null;
+        }
+
+        return new GroupWatcherDto
+        {
+            Id = user.Id,
+            Name = user.Name,
+            PrimaryImageTag = user.PrimaryImageTag,
+            HasPrimaryImage = user.HasPrimaryImage,
+            ImageUrl = user.ImageUrl,
+            Played = played,
+            PlaybackPositionTicks = playbackPositionTicks
+        };
+    }
 }

--- a/Jellyfin.Plugin.BingeBuddy/Services/UserProfileService.cs
+++ b/Jellyfin.Plugin.BingeBuddy/Services/UserProfileService.cs
@@ -66,7 +66,13 @@ public class UserProfileService : IUserProfileService
     }
 
     /// <inheritdoc />
-    public GroupWatcherDto? MapWatcher(Guid userId, bool played, long playbackPositionTicks, int avatarSize = 88)
+    public GroupWatcherDto? MapWatcher(
+        Guid userId,
+        bool played,
+        long playbackPositionTicks,
+        int avatarSize = 88,
+        int? episodeIndexNumber = null,
+        long episodeRunTimeTicks = 0)
     {
         var user = MapUser(userId, avatarSize);
         if (user is null)
@@ -82,7 +88,9 @@ public class UserProfileService : IUserProfileService
             HasPrimaryImage = user.HasPrimaryImage,
             ImageUrl = user.ImageUrl,
             Played = played,
-            PlaybackPositionTicks = playbackPositionTicks
+            PlaybackPositionTicks = playbackPositionTicks,
+            EpisodeIndexNumber = episodeIndexNumber,
+            EpisodeRunTimeTicks = episodeRunTimeTicks
         };
     }
 }

--- a/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.css
+++ b/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.css
@@ -54,11 +54,11 @@
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    gap: 0.35rem;
-    width: 8rem;
-    max-width: 8rem;
+    gap: 0.5rem;
+    width: 20rem;
+    max-width: 20rem;
     min-width: 0;
-    padding: 0.5rem 0.35rem;
+    padding: 0.75rem 0.65rem;
     border-radius: 0.5rem;
     background: rgba(255, 255, 255, 0.04);
     box-sizing: border-box;
@@ -98,4 +98,76 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.bb-detail-progress {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    width: 100%;
+    margin-top: 0.15rem;
+}
+
+.bb-detail-progress-heading {
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    opacity: 0.72;
+    text-transform: uppercase;
+}
+
+.bb-detail-progress-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.bb-detail-progress-meta {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+    width: 100%;
+    min-width: 0;
+}
+
+.bb-detail-progress-label {
+    flex-shrink: 0;
+    font-size: 0.74rem;
+    font-weight: 600;
+    opacity: 0.9;
+}
+
+.bb-detail-progress-status {
+    flex: 1;
+    min-width: 0;
+    font-size: 0.68rem;
+    line-height: 1.25;
+    text-align: right;
+    opacity: 0.82;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.bb-detail-progress-track {
+    width: 100%;
+    height: 0.45rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    overflow: hidden;
+}
+
+.bb-detail-progress-fill {
+    height: 100%;
+    border-radius: 999px;
+    transition: width 0.2s ease;
+}
+
+.bb-detail-progress-fill-you {
+    background: #9e9e9e;
+}
+
+.bb-detail-progress-fill-them {
+    background: #f17471;
 }

--- a/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.css
+++ b/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.css
@@ -53,18 +53,20 @@
 .bb-detail-buddy-card {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
     gap: 0.35rem;
-    min-width: 4.5rem;
-    max-width: 5.5rem;
+    width: 8rem;
+    max-width: 8rem;
+    min-width: 0;
     padding: 0.5rem 0.35rem;
     border-radius: 0.5rem;
     background: rgba(255, 255, 255, 0.04);
+    box-sizing: border-box;
 }
 
 .bb-detail-buddy-avatar {
-    width: 2.75rem;
-    height: 2.75rem;
+    width: 4rem;
+    height: 4rem;
     border-radius: 50%;
     border: 2px solid rgba(255, 255, 255, 0.85);
     box-sizing: border-box;
@@ -72,6 +74,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    align-self: center;
     color: #fff;
     font-size: 0.95rem;
     font-weight: 700;
@@ -84,7 +87,11 @@
 }
 
 .bb-detail-buddy-name {
+    display: block;
     width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
     font-size: 0.78rem;
     line-height: 1.2;
     text-align: center;

--- a/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.css
+++ b/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.css
@@ -48,6 +48,10 @@
     margin-bottom: 1.5em;
 }
 
+.detailPagePrimaryContent > .bb-detail-buddies {
+    margin-bottom: 1.25em;
+}
+
 .bb-detail-buddies-grid {
     display: flex;
     flex-wrap: wrap;

--- a/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.css
+++ b/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.css
@@ -38,3 +38,57 @@
 .bb-watcher-more {
     background: rgba(120, 120, 120, 0.95);
 }
+
+.bb-detail-buddies {
+    margin-top: 1.5em;
+}
+
+.bb-detail-buddies-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+}
+
+.bb-detail-buddy-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    min-width: 4.5rem;
+    max-width: 5.5rem;
+    padding: 0.5rem 0.35rem;
+    border-radius: 0.5rem;
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.bb-detail-buddy-avatar {
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.85);
+    box-sizing: border-box;
+    object-fit: cover;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 0.95rem;
+    font-weight: 700;
+    line-height: 1;
+    flex-shrink: 0;
+}
+
+.bb-detail-buddy-initial {
+    background: rgba(0, 164, 220, 0.85);
+}
+
+.bb-detail-buddy-name {
+    width: 100%;
+    font-size: 0.78rem;
+    line-height: 1.2;
+    text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.css
+++ b/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.css
@@ -43,6 +43,11 @@
     margin-top: 1.5em;
 }
 
+.bb-detail-buddies-season {
+    margin-top: 0;
+    margin-bottom: 1.5em;
+}
+
 .bb-detail-buddies-grid {
     display: flex;
     flex-wrap: wrap;
@@ -62,6 +67,11 @@
     border-radius: 0.5rem;
     background: rgba(255, 255, 255, 0.04);
     box-sizing: border-box;
+}
+
+.bb-detail-buddies-season .bb-detail-buddy-card {
+    width: 22rem;
+    max-width: 22rem;
 }
 
 .bb-detail-buddy-avatar {
@@ -136,6 +146,13 @@
     font-size: 0.74rem;
     font-weight: 600;
     opacity: 0.9;
+}
+
+.bb-detail-progress-episode {
+    font-size: 0.72rem;
+    font-weight: 600;
+    line-height: 1.2;
+    opacity: 0.88;
 }
 
 .bb-detail-progress-status {

--- a/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.js
+++ b/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.js
@@ -142,17 +142,28 @@
 
     function parseWatchProgress(raw) {
         if (!raw) {
-            return { played: false, playbackPositionTicks: 0 };
+            return {
+                played: false,
+                playbackPositionTicks: 0,
+                episodeIndexNumber: null,
+                episodeRunTimeTicks: 0
+            };
         }
+
+        let episodeIndexNumber = raw.episodeIndexNumber ?? raw.EpisodeIndexNumber;
 
         return {
             played: !!(raw.played || raw.Played),
-            playbackPositionTicks: Number(raw.playbackPositionTicks || raw.PlaybackPositionTicks || 0)
+            playbackPositionTicks: Number(raw.playbackPositionTicks || raw.PlaybackPositionTicks || 0),
+            episodeIndexNumber: episodeIndexNumber === undefined || episodeIndexNumber === null
+                ? null
+                : Number(episodeIndexNumber),
+            episodeRunTimeTicks: Number(raw.episodeRunTimeTicks || raw.EpisodeRunTimeTicks || 0)
         };
     }
 
     function parseWatcher(raw) {
-        var progress = parseWatchProgress(raw);
+        let progress = parseWatchProgress(raw);
 
         return {
             Name: raw.Name || raw.name || '',
@@ -160,7 +171,9 @@
             ImageUrl: raw.ImageUrl || raw.imageUrl || '',
             imageUrl: raw.ImageUrl || raw.imageUrl || '',
             played: progress.played,
-            playbackPositionTicks: progress.playbackPositionTicks
+            playbackPositionTicks: progress.playbackPositionTicks,
+            episodeIndexNumber: progress.episodeIndexNumber,
+            episodeRunTimeTicks: progress.episodeRunTimeTicks
         };
     }
 
@@ -169,7 +182,8 @@
             return {
                 watchers: [],
                 runTimeTicks: 0,
-                currentUser: { played: false, playbackPositionTicks: 0 }
+                isSeason: false,
+                currentUser: parseWatchProgress(null)
             };
         }
 
@@ -177,15 +191,33 @@
             return {
                 watchers: raw.map(parseWatcher),
                 runTimeTicks: 0,
-                currentUser: { played: false, playbackPositionTicks: 0 }
+                isSeason: false,
+                currentUser: parseWatchProgress(null)
             };
         }
 
         return {
             watchers: (raw.watchers || raw.Watchers || []).map(parseWatcher),
             runTimeTicks: Number(raw.runTimeTicks || raw.RunTimeTicks || 0),
+            isSeason: !!(raw.isSeason || raw.IsSeason),
             currentUser: parseWatchProgress(raw.currentUser || raw.CurrentUser)
         };
+    }
+
+    function getProgressRuntime(progress, fallbackRunTimeTicks) {
+        if (progress && progress.episodeRunTimeTicks > 0) {
+            return progress.episodeRunTimeTicks;
+        }
+
+        return fallbackRunTimeTicks || 0;
+    }
+
+    function formatProgressLabel(labelText, episodeIndexNumber) {
+        if (episodeIndexNumber === null || episodeIndexNumber === undefined) {
+            return labelText;
+        }
+
+        return labelText + ' · Ep. ' + episodeIndexNumber;
     }
 
     function getProgressPercent(played, playbackPositionTicks, runTimeTicks) {
@@ -201,10 +233,10 @@
     }
 
     function formatWatchedDuration(playbackPositionTicks) {
-        var totalSeconds = Math.max(0, Math.floor(playbackPositionTicks / TICKS_PER_SECOND));
-        var hours = Math.floor(totalSeconds / 3600);
-        var minutes = Math.floor((totalSeconds % 3600) / 60);
-        var seconds = totalSeconds % 60;
+        let totalSeconds = Math.max(0, Math.floor(playbackPositionTicks / TICKS_PER_SECOND));
+        let hours = Math.floor(totalSeconds / 3600);
+        let minutes = Math.floor((totalSeconds % 3600) / 60);
+        let seconds = totalSeconds % 60;
 
         if (hours >= 1) {
             return hours + 'h ' + minutes + 'm ' + seconds + 's';
@@ -218,23 +250,27 @@
             return 'Finished';
         }
 
-        var watched = formatWatchedDuration(playbackPositionTicks);
-        var percent = getProgressPercent(false, playbackPositionTicks, runTimeTicks);
+        let watched = formatWatchedDuration(playbackPositionTicks);
+        let percent = getProgressPercent(false, playbackPositionTicks, runTimeTicks);
         return watched + ' watched (' + percent + '%)';
     }
 
-    function createProgressRow(labelText, progress, runTimeTicks, variant) {
-        var row = document.createElement('div');
+    function createProgressRow(labelText, progress, runTimeTicks, let iant, options) {
+        options = options || {};
+        let episodeIndexNumber = options.episodeIndexNumber;
+        let showEpisodeLine = options.showEpisodeLine;
+
+        let row = document.createElement('div');
         row.className = 'bb-detail-progress-row';
 
-        var meta = document.createElement('div');
+        let meta = document.createElement('div');
         meta.className = 'bb-detail-progress-meta';
 
-        var label = document.createElement('span');
+        let label = document.createElement('span');
         label.className = 'bb-detail-progress-label';
         label.textContent = labelText;
 
-        var status = document.createElement('span');
+        let status = document.createElement('span');
         status.className = 'bb-detail-progress-status';
         status.textContent = formatProgressStatus(
             progress.played,
@@ -244,12 +280,20 @@
 
         meta.appendChild(label);
         meta.appendChild(status);
+        row.appendChild(meta);
 
-        var track = document.createElement('div');
+        if (showEpisodeLine && episodeIndexNumber !== null && episodeIndexNumber !== undefined) {
+            let episodeLine = document.createElement('div');
+            episodeLine.className = 'bb-detail-progress-episode';
+            episodeLine.textContent = 'Episode ' + episodeIndexNumber;
+            row.appendChild(episodeLine);
+        }
+
+        let track = document.createElement('div');
         track.className = 'bb-detail-progress-track';
 
-        var fill = document.createElement('div');
-        fill.className = 'bb-detail-progress-fill bb-detail-progress-fill-' + variant;
+        let fill = document.createElement('div');
+        fill.className = 'bb-detail-progress-fill bb-detail-progress-fill-' + let iant;
         fill.style.width = getProgressPercent(
             progress.played,
             progress.playbackPositionTicks,
@@ -257,26 +301,36 @@
         ) + '%';
 
         track.appendChild(fill);
-        row.appendChild(meta);
         row.appendChild(track);
 
         return row;
     }
 
-    function createDetailProgressSection(currentUser, watcher, runTimeTicks) {
-        var section = document.createElement('div');
+    function createDetailProgressSection(currentUser, watcher, overlay) {
+        let section = document.createElement('div');
         section.className = 'bb-detail-progress';
 
-        var heading = document.createElement('div');
+        let heading = document.createElement('div');
         heading.className = 'bb-detail-progress-heading';
         heading.textContent = 'Progress';
         section.appendChild(heading);
 
-        section.appendChild(createProgressRow('You', currentUser, runTimeTicks, 'you'));
-        section.appendChild(createProgressRow('Them', {
-            played: watcher.played,
-            playbackPositionTicks: watcher.playbackPositionTicks
-        }, runTimeTicks, 'them'));
+        let isSeason = overlay.isSeason;
+        let youRuntime = isSeason
+            ? getProgressRuntime(currentUser, 0)
+            : overlay.runTimeTicks;
+        let themRuntime = isSeason
+            ? getProgressRuntime(watcher, 0)
+            : overlay.runTimeTicks;
+
+        section.appendChild(createProgressRow('You', currentUser, youRuntime, 'you', {
+            showEpisodeLine: isSeason,
+            episodeIndexNumber: isSeason ? currentUser.episodeIndexNumber : null
+        }));
+        section.appendChild(createProgressRow('Them', watcher, themRuntime, 'them', {
+            showEpisodeLine: isSeason,
+            episodeIndexNumber: isSeason ? watcher.episodeIndexNumber : null
+        }));
 
         return section;
     }
@@ -334,7 +388,7 @@
         card.appendChild(createDetailProgressSection(
             overlay.currentUser,
             watcher,
-            overlay.runTimeTicks
+            overlay
         ));
 
         return card;
@@ -344,12 +398,18 @@
         removeDetailBuddiesSection(detailSection);
         detailSection.dataset.bbDetailBuddiesItemId = itemId;
 
+        overlay = parseItemOverlay(overlay);
+
         if (!overlay || !overlay.watchers || !overlay.watchers.length) {
             return;
         }
 
         let section = document.createElement('div');
         section.className = DETAIL_BUDDIES_CLASS + ' verticalSection detailVerticalSection';
+
+        if (overlay.isSeason) {
+            section.classList.add('bb-detail-buddies-season');
+        }
 
         let title = document.createElement('h2');
         title.className = 'sectionTitle';
@@ -364,7 +424,7 @@
         });
 
         section.appendChild(grid);
-        detailSection.appendChild(section);
+        detailSection.insertBefore(section, detailSection.firstChild);
     }
 
     function renderDetailBuddiesForItem(itemId, overlay) {

--- a/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.js
+++ b/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.js
@@ -5,12 +5,14 @@
         return;
     }
 
-    var CARD_SELECTOR = 'a.cardImageContainer.cardContent, div.listItemImage';
-    var OVERLAY_CLASS = 'bb-watcher-stack';
-    var pendingItemIds = new Set();
-    var overlayCache = new Map();
-    var fetchTimer = null;
-    var observer = null;
+    let CARD_SELECTOR = 'a.cardImageContainer.cardContent, div.listItemImage';
+    let DETAIL_SECTION_SELECTOR = '.detailSection';
+    let OVERLAY_CLASS = 'bb-watcher-stack';
+    let DETAIL_BUDDIES_CLASS = 'bb-detail-buddies';
+    let pendingItemIds = new Set();
+    let overlayCache = new Map();
+    let fetchTimer = null;
+    let observer = null;
 
     function normalizeGuid(value) {
         return (value || '').toString().replace(/-/g, '').toLowerCase();
@@ -21,22 +23,22 @@
     }
 
     function extractItemId(element) {
-        var card = findCardRoot(element);
+        let card = findCardRoot(element);
         if (card && card.dataset && card.dataset.id) {
             return card.dataset.id;
         }
 
-        var link = element.closest('a[href*="id="]');
+        let link = element.closest('a[href*="id="]');
         if (link && link.href) {
-            var match = link.href.match(/[?&]id=([a-f0-9-]{32,36})/i);
+            let match = link.href.match(/[?&]id=([a-f0-9-]{32,36})/i);
             if (match) {
                 return match[1];
             }
         }
 
-        var image = element.querySelector('img[data-src], img[src]') || element;
-        var source = image.getAttribute('data-src') || image.getAttribute('src') || '';
-        var imageMatch = source.match(/\/Items\/([a-f0-9-]{32,36})\//i);
+        let image = element.querySelector('img[data-src], img[src]') || element;
+        let source = image.getAttribute('data-src') || image.getAttribute('src') || '';
+        let imageMatch = source.match(/\/Items\/([a-f0-9-]{32,36})\//i);
         if (imageMatch) {
             return imageMatch[1];
         }
@@ -61,12 +63,12 @@
     }
 
     function getInitial(name) {
-        var trimmed = (name || '').trim();
+        let trimmed = (name || '').trim();
         return trimmed ? trimmed.charAt(0).toUpperCase() : '?';
     }
 
     function removeExistingOverlay(mount) {
-        var existing = mount.querySelector('.' + OVERLAY_CLASS);
+        let existing = mount.querySelector('.' + OVERLAY_CLASS);
         if (existing) {
             existing.remove();
         }
@@ -79,16 +81,16 @@
             return;
         }
 
-        var stack = document.createElement('div');
+        let stack = document.createElement('div');
         stack.className = OVERLAY_CLASS;
 
-        var visibleWatchers = watchers.slice(0, 3);
+        let visibleWatchers = watchers.slice(0, 3);
         visibleWatchers.forEach(function (watcher, index) {
-            var name = watcher.Name || watcher.name || '';
-            var imageUrl = resolveImageUrl(watcher.ImageUrl || watcher.imageUrl);
+            let name = watcher.Name || watcher.name || '';
+            let imageUrl = resolveImageUrl(watcher.ImageUrl || watcher.imageUrl);
 
             if (imageUrl) {
-                var img = document.createElement('img');
+                let img = document.createElement('img');
                 img.className = 'bb-watcher-avatar';
                 img.alt = name;
                 img.title = name;
@@ -104,7 +106,7 @@
         });
 
         if (watchers.length > 3) {
-            var more = document.createElement('span');
+            let more = document.createElement('span');
             more.count = watchers.length - 3;
             more.className = 'bb-watcher-more';
             more.textContent = more.count > 99 ? '99+' : '+' + more.count;
@@ -119,12 +121,140 @@
     }
 
     function createInitialAvatar(name, index) {
-        var avatar = document.createElement('span');
+        let avatar = document.createElement('span');
         avatar.className = 'bb-watcher-avatar bb-watcher-initial';
         avatar.textContent = getInitial(name);
         avatar.title = name;
         avatar.style.zIndex = String(index + 1);
         return avatar;
+    }
+
+    function getDetailsItemIdFromHash() {
+        let hash = window.location.hash || '';
+        if (hash.indexOf('/details') === -1) {
+            return null;
+        }
+
+        let match = hash.match(/[?&]id=([a-f0-9-]{32,36})/i);
+        return match ? match[1] : null;
+    }
+
+    function getWatchersFromResponse(response, itemId) {
+        if (!response) {
+            return [];
+        }
+
+        return response[normalizeGuid(itemId)] || response[itemId] || [];
+    }
+
+    function removeDetailBuddiesSection(detailSection) {
+        let existing = detailSection.querySelector('.' + DETAIL_BUDDIES_CLASS);
+        if (existing) {
+            existing.remove();
+        }
+    }
+
+    function createDetailInitialAvatar(name) {
+        let avatar = document.createElement('span');
+        avatar.className = 'bb-detail-buddy-avatar bb-detail-buddy-initial';
+        avatar.textContent = getInitial(name);
+        avatar.title = name;
+        return avatar;
+    }
+
+    function renderDetailBuddyCard(watcher) {
+        let card = document.createElement('div');
+        card.className = 'bb-detail-buddy-card';
+
+        let name = watcher.Name || watcher.name || '';
+        let imageUrl = resolveImageUrl(watcher.ImageUrl || watcher.imageUrl);
+
+        if (imageUrl) {
+            let img = document.createElement('img');
+            img.className = 'bb-detail-buddy-avatar';
+            img.alt = name;
+            img.title = name;
+            img.src = imageUrl;
+            img.addEventListener('error', function () {
+                img.replaceWith(createDetailInitialAvatar(name));
+            });
+            card.appendChild(img);
+        } else {
+            card.appendChild(createDetailInitialAvatar(name));
+        }
+
+        let label = document.createElement('span');
+        label.className = 'bb-detail-buddy-name';
+        label.textContent = name;
+        label.title = name;
+        card.appendChild(label);
+
+        return card;
+    }
+
+    function renderDetailBuddiesSection(detailSection, itemId, watchers) {
+        removeDetailBuddiesSection(detailSection);
+        detailSection.dataset.bbDetailBuddiesItemId = itemId;
+
+        if (!watchers || !watchers.length) {
+            return;
+        }
+
+        let section = document.createElement('div');
+        section.className = DETAIL_BUDDIES_CLASS + ' verticalSection detailVerticalSection';
+
+        let title = document.createElement('h2');
+        title.className = 'sectionTitle';
+        title.textContent = 'Binge buddies';
+        section.appendChild(title);
+
+        let grid = document.createElement('div');
+        grid.className = 'bb-detail-buddies-grid focuscontainer-x';
+
+        watchers.forEach(function (watcher) {
+            grid.appendChild(renderDetailBuddyCard(watcher));
+        });
+
+        section.appendChild(grid);
+        detailSection.appendChild(section);
+    }
+
+    function renderDetailBuddiesForItem(itemId, watchers) {
+        let detailSection = document.querySelector(DETAIL_SECTION_SELECTOR);
+        if (!detailSection || getDetailsItemIdFromHash() !== itemId) {
+            return;
+        }
+
+        renderDetailBuddiesSection(detailSection, itemId, watchers);
+    }
+
+    function queueDetailBuddiesFetch(itemId) {
+        if (!itemId) {
+            return;
+        }
+
+        queueFetch(itemId);
+    }
+
+    function scanDetailPage() {
+        let itemId = getDetailsItemIdFromHash();
+        let detailSection = document.querySelector(DETAIL_SECTION_SELECTOR);
+
+        if (!itemId || !detailSection) {
+            return;
+        }
+
+        if (detailSection.dataset.bbDetailBuddiesItemId === itemId) {
+            return;
+        }
+
+        let cached = overlayCache.get(normalizeGuid(itemId));
+        if (cached) {
+            renderDetailBuddiesSection(detailSection, itemId, cached);
+            return;
+        }
+
+        queueDetailBuddiesFetch(itemId);
     }
 
     function queueFetch(itemId) {
@@ -142,14 +272,14 @@
     }
 
     function fetchPendingOverlays() {
-        var itemIds = Array.from(pendingItemIds);
+        let itemIds = Array.from(pendingItemIds);
         pendingItemIds.clear();
 
         if (!itemIds.length || !ApiClient.getCurrentUserId || !ApiClient.getCurrentUserId()) {
             return;
         }
 
-        var query = itemIds.map(function (itemId) {
+        let query = itemIds.map(function (itemId) {
             return 'itemIds=' + encodeURIComponent(itemId);
         }).join('&');
 
@@ -163,15 +293,19 @@
             });
 
             document.querySelectorAll(CARD_SELECTOR).forEach(function (container) {
-                var itemId = extractItemId(container);
+                let itemId = extractItemId(container);
                 if (!itemId) {
                     return;
                 }
 
-                var watchers = overlayCache.get(normalizeGuid(itemId));
+                let watchers = overlayCache.get(normalizeGuid(itemId));
                 if (watchers) {
                     renderOverlay(getMountPoint(container), watchers);
                 }
+            });
+
+            itemIds.forEach(function (itemId) {
+                renderDetailBuddiesForItem(itemId, getWatchersFromResponse(response, itemId));
             });
         });
     }
@@ -181,14 +315,14 @@
             return;
         }
 
-        var itemId = extractItemId(container);
+        let itemId = extractItemId(container);
         if (!itemId) {
             return;
         }
 
         container.dataset.bbWatcherProcessed = 'true';
 
-        var cached = overlayCache.get(normalizeGuid(itemId));
+        let cached = overlayCache.get(normalizeGuid(itemId));
         if (cached) {
             renderOverlay(getMountPoint(container), cached);
             return;
@@ -208,6 +342,7 @@
 
         observer = new MutationObserver(function () {
             scanCards(document);
+            scanDetailPage();
         });
 
         observer.observe(document.body, {
@@ -217,8 +352,18 @@
     }
 
     scanCards(document);
+    scanDetailPage();
     setupObserver();
     document.addEventListener('viewshow', function () {
         scanCards(document);
+        scanDetailPage();
+    });
+    window.addEventListener('hashchange', function () {
+        let detailSection = document.querySelector(DETAIL_SECTION_SELECTOR);
+        if (detailSection) {
+            delete detailSection.dataset.bbDetailBuddiesItemId;
+        }
+
+        scanDetailPage();
     });
 })();

--- a/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.js
+++ b/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.js
@@ -9,6 +9,7 @@
     let DETAIL_SECTION_SELECTOR = '.detailSection';
     let OVERLAY_CLASS = 'bb-watcher-stack';
     let DETAIL_BUDDIES_CLASS = 'bb-detail-buddies';
+    let TICKS_PER_SECOND = 10000000;
     let pendingItemIds = new Set();
     let overlayCache = new Map();
     let fetchTimer = null;
@@ -139,12 +140,153 @@
         return match ? match[1] : null;
     }
 
-    function getWatchersFromResponse(response, itemId) {
-        if (!response) {
-            return [];
+    function parseWatchProgress(raw) {
+        if (!raw) {
+            return { played: false, playbackPositionTicks: 0 };
         }
 
-        return response[normalizeGuid(itemId)] || response[itemId] || [];
+        return {
+            played: !!(raw.played || raw.Played),
+            playbackPositionTicks: Number(raw.playbackPositionTicks || raw.PlaybackPositionTicks || 0)
+        };
+    }
+
+    function parseWatcher(raw) {
+        var progress = parseWatchProgress(raw);
+
+        return {
+            Name: raw.Name || raw.name || '',
+            name: raw.Name || raw.name || '',
+            ImageUrl: raw.ImageUrl || raw.imageUrl || '',
+            imageUrl: raw.ImageUrl || raw.imageUrl || '',
+            played: progress.played,
+            playbackPositionTicks: progress.playbackPositionTicks
+        };
+    }
+
+    function parseItemOverlay(raw) {
+        if (!raw) {
+            return {
+                watchers: [],
+                runTimeTicks: 0,
+                currentUser: { played: false, playbackPositionTicks: 0 }
+            };
+        }
+
+        if (Array.isArray(raw)) {
+            return {
+                watchers: raw.map(parseWatcher),
+                runTimeTicks: 0,
+                currentUser: { played: false, playbackPositionTicks: 0 }
+            };
+        }
+
+        return {
+            watchers: (raw.watchers || raw.Watchers || []).map(parseWatcher),
+            runTimeTicks: Number(raw.runTimeTicks || raw.RunTimeTicks || 0),
+            currentUser: parseWatchProgress(raw.currentUser || raw.CurrentUser)
+        };
+    }
+
+    function getProgressPercent(played, playbackPositionTicks, runTimeTicks) {
+        if (played) {
+            return 100;
+        }
+
+        if (!runTimeTicks || runTimeTicks <= 0) {
+            return 0;
+        }
+
+        return Math.min(100, Math.round((playbackPositionTicks / runTimeTicks) * 100));
+    }
+
+    function formatWatchedDuration(playbackPositionTicks) {
+        var totalSeconds = Math.max(0, Math.floor(playbackPositionTicks / TICKS_PER_SECOND));
+        var hours = Math.floor(totalSeconds / 3600);
+        var minutes = Math.floor((totalSeconds % 3600) / 60);
+        var seconds = totalSeconds % 60;
+
+        if (hours >= 1) {
+            return hours + 'h ' + minutes + 'm ' + seconds + 's';
+        }
+
+        return minutes + 'm ' + seconds + 's';
+    }
+
+    function formatProgressStatus(played, playbackPositionTicks, runTimeTicks) {
+        if (played) {
+            return 'Finished';
+        }
+
+        var watched = formatWatchedDuration(playbackPositionTicks);
+        var percent = getProgressPercent(false, playbackPositionTicks, runTimeTicks);
+        return watched + ' watched (' + percent + '%)';
+    }
+
+    function createProgressRow(labelText, progress, runTimeTicks, variant) {
+        var row = document.createElement('div');
+        row.className = 'bb-detail-progress-row';
+
+        var meta = document.createElement('div');
+        meta.className = 'bb-detail-progress-meta';
+
+        var label = document.createElement('span');
+        label.className = 'bb-detail-progress-label';
+        label.textContent = labelText;
+
+        var status = document.createElement('span');
+        status.className = 'bb-detail-progress-status';
+        status.textContent = formatProgressStatus(
+            progress.played,
+            progress.playbackPositionTicks,
+            runTimeTicks
+        );
+
+        meta.appendChild(label);
+        meta.appendChild(status);
+
+        var track = document.createElement('div');
+        track.className = 'bb-detail-progress-track';
+
+        var fill = document.createElement('div');
+        fill.className = 'bb-detail-progress-fill bb-detail-progress-fill-' + variant;
+        fill.style.width = getProgressPercent(
+            progress.played,
+            progress.playbackPositionTicks,
+            runTimeTicks
+        ) + '%';
+
+        track.appendChild(fill);
+        row.appendChild(meta);
+        row.appendChild(track);
+
+        return row;
+    }
+
+    function createDetailProgressSection(currentUser, watcher, runTimeTicks) {
+        var section = document.createElement('div');
+        section.className = 'bb-detail-progress';
+
+        var heading = document.createElement('div');
+        heading.className = 'bb-detail-progress-heading';
+        heading.textContent = 'Progress';
+        section.appendChild(heading);
+
+        section.appendChild(createProgressRow('You', currentUser, runTimeTicks, 'you'));
+        section.appendChild(createProgressRow('Them', {
+            played: watcher.played,
+            playbackPositionTicks: watcher.playbackPositionTicks
+        }, runTimeTicks, 'them'));
+
+        return section;
+    }
+
+    function getItemOverlayFromResponse(response, itemId) {
+        if (!response) {
+            return parseItemOverlay(null);
+        }
+
+        return parseItemOverlay(response[normalizeGuid(itemId)] || response[itemId]);
     }
 
     function removeDetailBuddiesSection(detailSection) {
@@ -162,7 +304,7 @@
         return avatar;
     }
 
-    function renderDetailBuddyCard(watcher) {
+    function renderDetailBuddyCard(watcher, overlay) {
         let card = document.createElement('div');
         card.className = 'bb-detail-buddy-card';
 
@@ -189,14 +331,20 @@
         label.title = name;
         card.appendChild(label);
 
+        card.appendChild(createDetailProgressSection(
+            overlay.currentUser,
+            watcher,
+            overlay.runTimeTicks
+        ));
+
         return card;
     }
 
-    function renderDetailBuddiesSection(detailSection, itemId, watchers) {
+    function renderDetailBuddiesSection(detailSection, itemId, overlay) {
         removeDetailBuddiesSection(detailSection);
         detailSection.dataset.bbDetailBuddiesItemId = itemId;
 
-        if (!watchers || !watchers.length) {
+        if (!overlay || !overlay.watchers || !overlay.watchers.length) {
             return;
         }
 
@@ -211,21 +359,21 @@
         let grid = document.createElement('div');
         grid.className = 'bb-detail-buddies-grid focuscontainer-x';
 
-        watchers.forEach(function (watcher) {
-            grid.appendChild(renderDetailBuddyCard(watcher));
+        overlay.watchers.forEach(function (watcher) {
+            grid.appendChild(renderDetailBuddyCard(watcher, overlay));
         });
 
         section.appendChild(grid);
         detailSection.appendChild(section);
     }
 
-    function renderDetailBuddiesForItem(itemId, watchers) {
+    function renderDetailBuddiesForItem(itemId, overlay) {
         let detailSection = document.querySelector(DETAIL_SECTION_SELECTOR);
         if (!detailSection || getDetailsItemIdFromHash() !== itemId) {
             return;
         }
 
-        renderDetailBuddiesSection(detailSection, itemId, watchers);
+        renderDetailBuddiesSection(detailSection, itemId, parseItemOverlay(overlay));
     }
 
     function queueDetailBuddiesFetch(itemId) {
@@ -289,7 +437,7 @@
             dataType: 'json'
         }).then(function (response) {
             Object.keys(response || {}).forEach(function (key) {
-                overlayCache.set(normalizeGuid(key), response[key] || []);
+                overlayCache.set(normalizeGuid(key), parseItemOverlay(response[key]));
             });
 
             document.querySelectorAll(CARD_SELECTOR).forEach(function (container) {
@@ -298,14 +446,14 @@
                     return;
                 }
 
-                let watchers = overlayCache.get(normalizeGuid(itemId));
-                if (watchers) {
-                    renderOverlay(getMountPoint(container), watchers);
+                let overlay = overlayCache.get(normalizeGuid(itemId));
+                if (overlay) {
+                    renderOverlay(getMountPoint(container), overlay.watchers);
                 }
             });
 
             itemIds.forEach(function (itemId) {
-                renderDetailBuddiesForItem(itemId, getWatchersFromResponse(response, itemId));
+                renderDetailBuddiesForItem(itemId, getItemOverlayFromResponse(response, itemId));
             });
         });
     }
@@ -324,7 +472,7 @@
 
         let cached = overlayCache.get(normalizeGuid(itemId));
         if (cached) {
-            renderOverlay(getMountPoint(container), cached);
+            renderOverlay(getMountPoint(container), cached.watchers);
             return;
         }
 

--- a/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.js
+++ b/Jellyfin.Plugin.BingeBuddy/Web/js/overlays.js
@@ -7,12 +7,18 @@
 
     let CARD_SELECTOR = 'a.cardImageContainer.cardContent, div.listItemImage';
     let DETAIL_SECTION_SELECTOR = '.detailSection';
+    let DETAIL_MOUNT_SELECTOR = '.detailPagePrimaryContent';
     let OVERLAY_CLASS = 'bb-watcher-stack';
     let DETAIL_BUDDIES_CLASS = 'bb-detail-buddies';
+    let DETAIL_MOUNT_DATA_ATTR = 'bbDetailBuddiesItemId';
     let TICKS_PER_SECOND = 10000000;
+    let DETAIL_RETRY_MS = 150;
+    let DETAIL_RETRY_MAX = 40;
     let pendingItemIds = new Set();
     let overlayCache = new Map();
     let fetchTimer = null;
+    let detailRetryTimer = null;
+    let detailScanTimer = null;
     let observer = null;
 
     function normalizeGuid(value) {
@@ -212,14 +218,6 @@
         return fallbackRunTimeTicks || 0;
     }
 
-    function formatProgressLabel(labelText, episodeIndexNumber) {
-        if (episodeIndexNumber === null || episodeIndexNumber === undefined) {
-            return labelText;
-        }
-
-        return labelText + ' · Ep. ' + episodeIndexNumber;
-    }
-
     function getProgressPercent(played, playbackPositionTicks, runTimeTicks) {
         if (played) {
             return 100;
@@ -255,7 +253,7 @@
         return watched + ' watched (' + percent + '%)';
     }
 
-    function createProgressRow(labelText, progress, runTimeTicks, let iant, options) {
+    function createProgressRow(labelText, progress, runTimeTicks, variant, options) {
         options = options || {};
         let episodeIndexNumber = options.episodeIndexNumber;
         let showEpisodeLine = options.showEpisodeLine;
@@ -293,7 +291,7 @@
         track.className = 'bb-detail-progress-track';
 
         let fill = document.createElement('div');
-        fill.className = 'bb-detail-progress-fill bb-detail-progress-fill-' + let iant;
+        fill.className = 'bb-detail-progress-fill bb-detail-progress-fill-' + variant;
         fill.style.width = getProgressPercent(
             progress.played,
             progress.playbackPositionTicks,
@@ -343,11 +341,87 @@
         return parseItemOverlay(response[normalizeGuid(itemId)] || response[itemId]);
     }
 
-    function removeDetailBuddiesSection(detailSection) {
-        let existing = detailSection.querySelector('.' + DETAIL_BUDDIES_CLASS);
-        if (existing) {
-            existing.remove();
+    function removeDetailBuddiesFromMount(mountPoint) {
+        if (!mountPoint) {
+            return;
         }
+
+        mountPoint.querySelectorAll('.' + DETAIL_BUDDIES_CLASS).forEach(function (element) {
+            element.remove();
+        });
+    }
+
+    function clearAllDetailBuddiesState() {
+        document.querySelectorAll('.' + DETAIL_BUDDIES_CLASS).forEach(function (element) {
+            element.remove();
+        });
+
+        document.querySelectorAll('[data-bb-detail-buddies-item-id]').forEach(function (element) {
+            delete element.dataset[DETAIL_MOUNT_DATA_ATTR];
+        });
+    }
+
+    function isElementVisible(element) {
+        if (!element) {
+            return false;
+        }
+
+        if (element.offsetParent !== null) {
+            return true;
+        }
+
+        return element.getClientRects().length > 0;
+    }
+
+    function findDetailMountPoint() {
+        let visiblePage = document.querySelector('.page:not(.hide)');
+        let candidates = [];
+
+        if (visiblePage) {
+            candidates = candidates.concat(Array.from(visiblePage.querySelectorAll(DETAIL_MOUNT_SELECTOR)));
+            candidates = candidates.concat(Array.from(visiblePage.querySelectorAll(DETAIL_SECTION_SELECTOR)));
+        }
+
+        candidates = candidates.concat(Array.from(document.querySelectorAll(DETAIL_MOUNT_SELECTOR)));
+        candidates = candidates.concat(Array.from(document.querySelectorAll(DETAIL_SECTION_SELECTOR)));
+
+        for (let i = 0; i < candidates.length; i++) {
+            if (isElementVisible(candidates[i])) {
+                return candidates[i];
+            }
+        }
+
+        return candidates.length ? candidates[candidates.length - 1] : null;
+    }
+
+    function getDetailInsertAnchor(mountPoint) {
+        if (!mountPoint) {
+            return null;
+        }
+
+        if (mountPoint.matches(DETAIL_MOUNT_SELECTOR)) {
+            return mountPoint.querySelector(DETAIL_SECTION_SELECTOR) || mountPoint.firstChild;
+        }
+
+        return mountPoint.firstChild;
+    }
+
+    function isDetailBuddiesMounted(mountPoint, itemId) {
+        if (!mountPoint) {
+            return false;
+        }
+
+        return mountPoint.dataset[DETAIL_MOUNT_DATA_ATTR] === itemId
+            && !!mountPoint.querySelector('.' + DETAIL_BUDDIES_CLASS);
+    }
+
+    function clearDetailBuddiesMountState(mountPoint) {
+        if (!mountPoint) {
+            return;
+        }
+
+        delete mountPoint.dataset[DETAIL_MOUNT_DATA_ATTR];
+        removeDetailBuddiesFromMount(mountPoint);
     }
 
     function createDetailInitialAvatar(name) {
@@ -394,14 +468,14 @@
         return card;
     }
 
-    function renderDetailBuddiesSection(detailSection, itemId, overlay) {
-        removeDetailBuddiesSection(detailSection);
-        detailSection.dataset.bbDetailBuddiesItemId = itemId;
+    function renderDetailBuddiesSection(mountPoint, itemId, overlay) {
+        removeDetailBuddiesFromMount(mountPoint);
+        delete mountPoint.dataset[DETAIL_MOUNT_DATA_ATTR];
 
         overlay = parseItemOverlay(overlay);
 
         if (!overlay || !overlay.watchers || !overlay.watchers.length) {
-            return;
+            return false;
         }
 
         let section = document.createElement('div');
@@ -424,16 +498,107 @@
         });
 
         section.appendChild(grid);
-        detailSection.insertBefore(section, detailSection.firstChild);
+
+        let insertAnchor = getDetailInsertAnchor(mountPoint);
+        if (insertAnchor) {
+            mountPoint.insertBefore(section, insertAnchor);
+        } else {
+            mountPoint.appendChild(section);
+        }
+
+        mountPoint.dataset[DETAIL_MOUNT_DATA_ATTR] = itemId;
+        return true;
     }
 
-    function renderDetailBuddiesForItem(itemId, overlay) {
-        let detailSection = document.querySelector(DETAIL_SECTION_SELECTOR);
-        if (!detailSection || getDetailsItemIdFromHash() !== itemId) {
+    function tryRenderDetailBuddies() {
+        let itemId = getDetailsItemIdFromHash();
+        if (!itemId) {
+            return true;
+        }
+
+        let mountPoint = findDetailMountPoint();
+        if (!mountPoint) {
+            return false;
+        }
+
+        if (isDetailBuddiesMounted(mountPoint, itemId)) {
+            return true;
+        }
+
+        if (mountPoint.dataset[DETAIL_MOUNT_DATA_ATTR]
+            && mountPoint.dataset[DETAIL_MOUNT_DATA_ATTR] !== itemId) {
+            clearDetailBuddiesMountState(mountPoint);
+        } else if (mountPoint.dataset[DETAIL_MOUNT_DATA_ATTR] === itemId) {
+            delete mountPoint.dataset[DETAIL_MOUNT_DATA_ATTR];
+        }
+
+        let cached = overlayCache.get(normalizeGuid(itemId));
+        if (cached) {
+            if (!cached.watchers || !cached.watchers.length) {
+                return true;
+            }
+
+            return renderDetailBuddiesSection(mountPoint, itemId, cached);
+        }
+
+        if (!pendingItemIds.has(itemId)) {
+            queueDetailBuddiesFetch(itemId);
+        }
+
+        return false;
+    }
+
+    function scheduleDetailBuddiesRetry(resetAttempts) {
+        if (resetAttempts) {
+            if (detailRetryTimer) {
+                clearTimeout(detailRetryTimer);
+                detailRetryTimer = null;
+            }
+        } else if (detailRetryTimer) {
             return;
         }
 
-        renderDetailBuddiesSection(detailSection, itemId, parseItemOverlay(overlay));
+        let attempts = 0;
+
+        function tick() {
+            detailRetryTimer = null;
+            attempts++;
+
+            if (!getDetailsItemIdFromHash()) {
+                return;
+            }
+
+            if (tryRenderDetailBuddies()) {
+                return;
+            }
+
+            if (attempts < DETAIL_RETRY_MAX) {
+                detailRetryTimer = setTimeout(tick, DETAIL_RETRY_MS);
+            }
+        }
+
+        detailRetryTimer = setTimeout(tick, 0);
+    }
+
+    function scheduleDetailBuddiesScan() {
+        if (detailScanTimer) {
+            clearTimeout(detailScanTimer);
+        }
+
+        detailScanTimer = setTimeout(function () {
+            detailScanTimer = null;
+            if (getDetailsItemIdFromHash()) {
+                scheduleDetailBuddiesRetry(true);
+            }
+        }, 80);
+    }
+
+    function scanDetailPage() {
+        if (!getDetailsItemIdFromHash()) {
+            return;
+        }
+
+        scheduleDetailBuddiesRetry(true);
     }
 
     function queueDetailBuddiesFetch(itemId) {
@@ -442,27 +607,6 @@
         }
 
         queueFetch(itemId);
-    }
-
-    function scanDetailPage() {
-        let itemId = getDetailsItemIdFromHash();
-        let detailSection = document.querySelector(DETAIL_SECTION_SELECTOR);
-
-        if (!itemId || !detailSection) {
-            return;
-        }
-
-        if (detailSection.dataset.bbDetailBuddiesItemId === itemId) {
-            return;
-        }
-
-        let cached = overlayCache.get(normalizeGuid(itemId));
-        if (cached) {
-            renderDetailBuddiesSection(detailSection, itemId, cached);
-            return;
-        }
-
-        queueDetailBuddiesFetch(itemId);
     }
 
     function queueFetch(itemId) {
@@ -476,7 +620,10 @@
             clearTimeout(fetchTimer);
         }
 
-        fetchTimer = setTimeout(fetchPendingOverlays, 120);
+        fetchTimer = setTimeout(function () {
+            fetchTimer = null;
+            fetchPendingOverlays();
+        }, 120);
     }
 
     function fetchPendingOverlays() {
@@ -512,9 +659,7 @@
                 }
             });
 
-            itemIds.forEach(function (itemId) {
-                renderDetailBuddiesForItem(itemId, getItemOverlayFromResponse(response, itemId));
-            });
+            scheduleDetailBuddiesRetry(true);
         });
     }
 
@@ -550,7 +695,7 @@
 
         observer = new MutationObserver(function () {
             scanCards(document);
-            scanDetailPage();
+            scheduleDetailBuddiesScan();
         });
 
         observer.observe(document.body, {
@@ -567,11 +712,7 @@
         scanDetailPage();
     });
     window.addEventListener('hashchange', function () {
-        let detailSection = document.querySelector(DETAIL_SECTION_SELECTOR);
-        if (detailSection) {
-            delete detailSection.dataset.bbDetailBuddiesItemId;
-        }
-
-        scanDetailPage();
+        clearAllDetailBuddiesState();
+        scheduleDetailBuddiesRetry(true);
     });
 })();

--- a/Jellyfin.Plugin.BingeBuddy/Web/js/plugin.js
+++ b/Jellyfin.Plugin.BingeBuddy/Web/js/plugin.js
@@ -49,7 +49,6 @@
         let script = document.createElement('script');
         script.id = 'binge-buddy-overlay-script';
         script.src = ApiClient.getUrl('BingeBuddy/js/overlays.js');
-        script.defer = true;
         document.head.appendChild(script);
     }
 

--- a/Jellyfin.Plugin.BingeBuddy/Web/js/plugin.js
+++ b/Jellyfin.Plugin.BingeBuddy/Web/js/plugin.js
@@ -1,7 +1,7 @@
 (function () {
     'use strict';
 
-    var BOOTSTRAP_FLAG = '__bingeBuddyBootstrapped';
+    let BOOTSTRAP_FLAG = '__bingeBuddyBootstrapped';
 
     if (window[BOOTSTRAP_FLAG]) {
         return;
@@ -13,8 +13,8 @@
             return;
         }
 
-        var attempts = 0;
-        var timer = setInterval(function () {
+        let attempts = 0;
+        let timer = setInterval(function () {
             if (typeof ApiClient !== 'undefined') {
                 clearInterval(timer);
                 callback();
@@ -32,7 +32,7 @@
             return;
         }
 
-        var link = document.createElement('link');
+        let link = document.createElement('link');
         link.id = 'binge-buddy-overlay-styles';
         link.rel = 'stylesheet';
         link.href = ApiClient.getUrl('BingeBuddy/js/overlays.css');
@@ -46,7 +46,7 @@
 
         loadStylesheet();
 
-        var script = document.createElement('script');
+        let script = document.createElement('script');
         script.id = 'binge-buddy-overlay-script';
         script.src = ApiClient.getUrl('BingeBuddy/js/overlays.js');
         script.defer = true;

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The overlay feature requires the **web UI**. Other Jellyfin clients (mobile apps
    - Check the Jellyfin users who should be in the group.
    - Click **Save members**.
 5. Repeat for any other groups you need.
+6. If the avatars are not showing up on the posters, just reload the page _ctrl + F5_ because the plugin injects the UI components on rendering. 
 
 Each server user who should see overlays must be included in at least one group with the people they watch with. Users who are not in any group with you will not appear on your posters, and you will not appear on theirs.
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 ## About
 
-**Binge Buddy** helps household and friend groups see what everyone has already started watching on your Jellyfin server. An admin creates **binge-watching groups**, picks which Jellyfin users belong to each group, and the web client shows small avatar stacks on movie and episode posters so you can spot shared progress at a glance.
+**Binge Buddy** helps household and friend groups see what everyone has already started watching on your Jellyfin server. An admin creates **binge-watching groups**, picks which Jellyfin users belong to each group, and the web client shows buddy avatars on posters plus **progress cards** on item detail pages so you can compare where everyone left off.
 
-Use it to plan the next watch session: open a library, see who has already begun a title, and pick up together without guessing where everyone left off.
+Use it to plan the next watch session: browse a library, open a movie or season, and see who has started what—and how far they are—without guessing.
 
 ## Requirements
 
 - Jellyfin **10.11.11** or later (plugin ABI `10.11.11.0`)
 - Administrative access to configure groups
-- Jellyfin **web client** for poster overlays
+- Jellyfin **web client** for overlays and detail cards
 
 ## Installation
 
@@ -34,34 +34,70 @@ A **group** is a named list of Jellyfin users on your server (for example, “Fr
 - Members are stored by user ID, not username, so renames on the server do not break membership.
 - A user can belong to multiple groups. When overlays are built, members from all of your groups are combined and deduplicated.
 
-Groups do **not** change Jellyfin permissions or libraries. They only define which users Binge Buddy treats as your “buddies” for progress overlays.
+Groups do **not** change Jellyfin permissions or libraries. They only define which users Binge Buddy treats as your “buddies” for progress display.
 
-### Poster Overlays
+### What counts as “started”
 
-When you browse movies or episodes in the **Jellyfin web client**, Binge Buddy adds a small stack of profile avatars to the bottom-left of each poster.
-
-For each title, the plugin looks at **every other member** in your groups and checks their personal Jellyfin play state for that item. A member is shown if they have **started** the title, meaning any of the following is true in their user data:
+For each buddy, Binge Buddy reads Jellyfin **user data** for the item (or for any episode in a season). Someone counts as having **started** if any of the following is true:
 
 - Marked as played
 - Play count greater than zero
 - Partial playback position saved
 - A last-played date recorded
 
-Watch history is read from Jellyfin’s user data store, so progress counts even if someone watched **before** they were added to a group.
+Watch history is retroactive—it counts even if someone watched **before** they were added to a group.
+
+You never see your own avatar on poster overlays; detail cards compare **You** vs **Them** instead.
+
+### Poster overlays
+
+When you browse in the **Jellyfin web client**, Binge Buddy adds a small stack of profile avatars to the **top-left** of supported thumbnails:
+
+| Item type | What it shows |
+|-----------|----------------|
+| **Movies** | Buddies who started that movie |
+| **Episodes** | Buddies who started that episode |
+| **Seasons** | Buddies who started **any episode** in that season |
 
 Display rules:
 
-- You never see your own avatar on a poster only other group members.
-- Up to **three** avatars are shown. If more buddies started the title, a **+N** badge appears for the rest.
-- Overlays appear on **movies and episodes** only (not folders, collections, or other item types).
+- Up to **three** avatars are shown; if more buddies qualify, a **+N** badge lists the rest on hover.
+- Hover an avatar or the **+N** badge to see names.
 
-The overlay feature requires the **web UI**. Other Jellyfin clients (mobile apps, TV apps, etc.) do not load the injected client script.
+Poster overlays require the **web UI**. Mobile and TV apps do not load the injected client script.
+
+### Detail page cards (movies & seasons)
+
+On **movie** and **season** detail pages, Binge Buddy injects a **Binge buddies** section with one card per group mate who has started the title (or any episode in the season).
+
+Each card shows:
+
+- Buddy **avatar** and **username**
+- A **Progress** block comparing **You** and **Them**
+
+For each row (**You** / **Them**), the card shows:
+
+- A status line, for example `45m 3s watched (86%)`, `1h 45m 13s watched (86%)`, or **`Finished`**
+- A rounded progress bar (**gray** for you, **coral** for them)
+
+**Finished** follows Jellyfin’s own played state (someone can finish during credits without being at 100% of the runtime bar). The bar is shown **full** when Jellyfin marks the item as played.
+
+#### Movies
+
+Cards appear at the **bottom** of the details section. Progress is based on that movie’s runtime.
+
+#### Seasons
+
+Cards appear at the **top** of the season view (above the episode list). Progress is based on each person’s **highest started episode** in that season—for example, if a buddy is on episode 7, the card shows **Episode 7** with that episode’s watch time and percentage.
 
 ## Features
 
 - Create and manage binge-watching groups from the plugin settings page
 - Pick members with checkboxes and profile avatars
-- Avatar stacks on movie and episode posters in the web client
+- Avatar stacks on **movie**, **episode**, and **season** posters in the web client
+- **Binge buddies** detail cards on **movie** and **season** pages
+- Side-by-side **You / Them** progress with time watched, percentage, and Jellyfin **Finished** state
+- Season cards show the **highest started episode** and that episode’s progress
 - Progress based on each user’s Jellyfin watch state (retroactive)
 
 ## Configuration
@@ -76,9 +112,8 @@ The overlay feature requires the **web UI**. Other Jellyfin clients (mobile apps
    - Check the Jellyfin users who should be in the group.
    - Click **Save members**.
 5. Repeat for any other groups you need.
-6. If the avatars are not showing up on the posters, just reload the page _ctrl + F5_ because the plugin injects the UI components on rendering. 
 
-Each server user who should see overlays must be included in at least one group with the people they watch with. Users who are not in any group with you will not appear on your posters, and you will not appear on theirs.
+Each server user who should see overlays and cards must be included in at least one group with the people they watch with. Users who are not in any group with you will not appear on your UI, and you will not appear on theirs.
 
 To remove a group, open it and use **Delete group** (with confirmation).
 
@@ -87,23 +122,24 @@ To remove a group, open it and use **Delete group** (with confirmation).
 After groups are configured:
 
 1. Sign in to Jellyfin in a **browser**.
-2. Open a movies or TV library.
-3. Look at the bottom-left of posters for stacked buddy avatars.
-4. Hover avatars or the **+N** badge to see names.
+2. **Library browsing** — look at poster thumbnails for stacked buddy avatars (movies, episodes, seasons).
+3. **Movie details** — scroll to **Binge buddies** for You vs Them progress on that film.
+4. **Season details** — **Binge buddies** appears at the top; each card shows the buddy’s furthest episode and progress.
 
-If no avatars appear on a title, no other member of your groups has started it yet or you may be the only member who has.
+If nothing appears for a title, no other group member has started it yet—or you may be the only one who has.
+
+If overlays or cards do not show up after an update, try a hard refresh (**Ctrl + F5**); the plugin injects UI as Jellyfin renders each view.
 
 ## Build
 
 1. Install the [.NET 9 SDK](https://dotnet.microsoft.com/download/dotnet/9.0).
 2. From the repository root, build and publish:
    ```bash
-   dotnet publish Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj --configuration Release --output bin
+   dotnet publish Jellyfin.Plugin.BingeBuddy/Jellyfin.Plugin.BingeBuddy.csproj --configuration Release --output bin
    ```
-3. Copy the published `Jellyfin.Plugin.Template.dll` into your Jellyfin plugins folder and restart the server.
+3. Copy the published `Jellyfin.Plugin.BingeBuddy.dll` (and related files) into your Jellyfin plugins folder and restart the server.
 
 Plugin metadata for catalog builds is defined in [`build.yaml`](./build.yaml).
-
 
 ## Contributing
 


### PR DESCRIPTION
This release adds detailed progress cards to help you see exactly where your buddies stopped watching.

### Added

* Progress cards on movie pages
* Progress cards on TV show seasons
* Episode, season, and timestamp details
* Buddy avatar indicators on seasons

### Improved

* More reliable UI rendering
* Better playback status retrieval

### Documentation

* Updated README with the new progress cards
* Added troubleshooting notes for first-time installation
